### PR TITLE
Update Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM amazonlinux:2023
+FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-core-runtime:1.0.3
 
 RUN dnf update -y && \
     dnf install -y \
-    make \
-    tar \
-    git \
-    zip \
-    wget \
-    unzip && \
+        git-2.50.1 \
+        make-4.3 \
+        tar-1.34 \
+        unzip-6.0 \
+        wget-1.21.3 \
+        zip-3.0 && \
     dnf clean all


### PR DESCRIPTION
Updates image to use `ci-core-runtime` as a base
Update packages and pin versions